### PR TITLE
Update q_interp.py

### DIFF
--- a/q_interp.py
+++ b/q_interp.py
@@ -1,19 +1,48 @@
+
+# coding: utf-8
+
+# In[1]:
+
 import pyfits
 import numpy as np
+# Set up matplotlib and use a nicer set of plot parameters
+get_ipython().magic(u'config InlineBackend.rc = {}')
+import matplotlib
+import matplotlib.pyplot as plt
+get_ipython().magic(u'matplotlib inline')
+from astropy.io import fits
 
-## After applying 'q_badpix' to a map with a very generous threshold (only extremely $
-##  we multiply the mask (the output from q_badpix) by the original image.
-## This gives us an image where all of the 'really bad' pixels are set to 0.
-## Then, we do a "first-pass# of interpolation: interpolate all of the 'lone bad pixe$
-## This translates to zeroe'd pixels, whose neighbors are all non-zero.
 
+# In[2]:
+####The 'helper function' suggestion, below, comes from the follwing very helpful Stack Exchange answer:
+#########http://stackoverflow.com/questions/6518811/interpolate-nan-values-in-a-numpy-array  -by user "eat"
+def nan_helper(row):
+    """Helper to handle indices and logical indices of NaNs.
+
+    Input:
+        - y, 1d numpy array with possible NaNs
+    Output:
+        - nans, logical indices of NaNs
+        - index, a function, with signature indices= index(logical_indices),
+          to convert logical indices of NaNs to 'equivalent' indices
+    Example:
+        >>> # linear interpolation of NaNs
+        >>> nans, x= nan_helper(y)
+        >>> y[nans]= np.interp(x(nans), x(~nans), y[~nans])
+    """
+
+    return np.isnan(row), lambda z: z.nonzero()[0]
+########################
+#######################
+# In[3]:
 
 ## Give the fits file name:
-masked_map = 'NL_OBJ_A01N_masked_test.fits'
-interpolated_map = 'NL_OBJ_A01N_1pix_int.fits'
+input_map = 'NL_SLIT1.fits'
+#interpolated_map_deadfix = 'NL_SLIT1_interp_deadfix.fits'
+interpolated_map_hotfix = 'NL_SLIT1_interp_hotfix.fits'
 
 ## Load the fits file into Python:
-hdulist = pyfits.open(masked_map)
+hdulist = pyfits.open(input_map)
 
 ## Get the file's data from the "HDU" structure, using the '.data' attribute:
 data = hdulist[0].data
@@ -22,17 +51,109 @@ data = hdulist[0].data
 print data.shape
 print data.dtype.name
 
-##
-print data[0,55,55]
+
+# In[4]:
+
+data_dead = np.copy(data[0])
+
+for y in range(0,240):
+        row = data_dead[y,:]
+        row_bad = np.where(row < -130.)
+        row[row_bad] = np.nan
+        nans, x= nan_helper(row)
+        row[nans]= np.interp(x(nans), x(~nans), row[~nans])
+        data_dead[y,:] = row
 
 
-for x in range(0,320):
-        for y in range(0,240):
-                if (data[0,y,x]=='nan' and data[0,y-1,x] !='nan' and
-data[0,y+1,x]
-!='nan'):
+# In[5]:
 
-                        data[0,y,x] = (data[0,y-1,x] + data[0,y+1,x])/ 2
+plt.imshow(data_dead, cmap='gray')
+plt.colorbar()
+
+
+# In[6]:
+
+data_hot = np.copy(data_dead)
+for y in range(0,240):
+        for x in range(0,320):
+                if 74 < y < 116 and 273 < x < 284: #This is to ignore the Y-range where the strong line emission appears
+                    continue
+                if data_hot[y,x] > 4000.:
+                        data_hot[y,x] = np.nan
+        row = data_hot[y,:]
+        nans, x= nan_helper(row)
+        row[nans]= np.interp(x(nans), x(~nans), row[~nans])
+        data_hot[y,:] = row
+
+
+# In[7]:
+
+plt.imshow(data_hot, cmap='gray')
+plt.colorbar()
+
+
+# In[8]:
+
+## Second pass of hot pixel interpolation - this time completely
+## excluding the bright source regions and line emission.
+## The process is the same as above, but with a lower threshold.
+## This should interpolate all of the bad pixels which are outside of the bright regions
+
+data_hot_2 = np.copy(data_hot)
+for y in range(0,240):
+        for x in range(0,320):
+                if 78 < y < 113 or 271 < x < 289: #This is to ignore the Y-range where the strong line emission appears
+                    continue
+                if data_hot_2[y,x] > 1000.:
+                        data_hot_2[y,x] = np.nan
+        row = data_hot_2[y,:]
+        nans, x= nan_helper(row)
+        row[nans]= np.interp(x(nans), x(~nans), row[~nans])
+        data_hot_2[y,:] = row
+
+
+# In[10]:
+
+plt.imshow(data_hot_2, cmap='gray')
+plt.colorbar()
+
+
+# In[17]:
+
+## Second pass of hot pixel interpolation - this time completely
+## excluding the bright source regions and line emission.
+## The process is the same as above, but with a lower threshold.
+## This should interpolate all of the bad pixels which are outside of the bright regions
+
+data_hot_3 = np.copy(data_hot_2)
+for y in range(0,240):
+        for x in range(0,320):
+                if (78 < y < 113) or (0 < x < 41) or (270 < x < 289): #This is to ignore the Y-range where the strong line emission appears
+                    continue
+                if data_hot_3[y,x] > 600.:
+                        data_hot_3[y,x] = np.nan
+        row = data_hot_3[y,:]
+        nans, x= nan_helper(row)
+        row[nans]= np.interp(x(nans), x(~nans), row[~nans])
+        data_hot_3[y,:] = row
+
+
+# In[19]:
+
+plt.imshow(data_hot_3, cmap='gray')
+plt.colorbar()
+
+
+# In[21]:
 
 ## Write the interpolated array to a file (keeping the header info):
-hdulist.writeto(interpolated_map, output_verify='ignore',clobber=True)
+data[0] = data_hot_3
+
+#hdulist.writeto(interpolated_map_deadfix, output_verify='ignore',clobber=True)
+hdulist.writeto(interpolated_map_hotfix, output_verify='ignore',clobber=True)
+
+
+# In[ ]:
+
+
+


### PR DESCRIPTION
Based on some closer inspection of the images and reading up on numpy/scipi etc. interpolation suggestions, I decided to break this problem down into a 1D process:

There's a lot of variation from pixel to pixel in the Y-dimension, but far less pixel-to-pixel variation along the X-dimension. The glaring exception is  X-positions that correspond to line emission- however there does not appear to be any bad pixels that fall on a line emission profile.

With that in mind, we'll:
1) read each row one by one
2) identify the "bad" positions
3) interpolate "new" values for the bad positions, using np.interp

1) and 3) are simple enough: the tricky part is identifying which pixels are bad. They are not labled as NaN, and there is no mask.

There a few patterns that they appear to follow, however: all pixels with a value less than -130. have the appearance of a "dead pixel". Pixels with values this low are surrounded by positive-valued pixels, except in the cases where the dead pixels occur in 2x2p blocks. The blocks themselves follow the same pattern though- the 12 pixels on the border are positive-valued, while the block pixels are very negative.

This means that we can at least proceed with the first wave of fixes: label the stranded, very negative pixels as NaN- then replace these with interpolated values.

The next step will be to determine a proper threshold for the "hot" pixels, which should be a similar process but may not a bit more thought. For now I'm implementing this in a serious of "passes". First I deal with the brightest pixels in the image, since these are brighter than even the brightest source pixels.

In the next two passes, I deal with the brightest isolated pixels/pixel-patches which are outside of the "source data" regions.

In the third pass, since the hot pixels are close to the level of the brightest sky emission lines, I also exclude the bright sky-dominated regions.
